### PR TITLE
Sprint 1 - Implementar HTTP/HTTPS y DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Proyecto 7 – Tester de vulnerabilidades en protocolos TLS
+
+**Práctica Calificada – Sección B**
+
+## Descripción general
+Este proyecto implementa un tester en Bash para analizar vulnerabilidades relacionadas con protocolos TLS, integrando chequeos de HTTP/HTTPS y DNS. El objetivo es generar evidencias reproducibles en `out/` y automatizar su validación con Makefile y Bats.
+
+## Requisitos
+- Bash
+- curl
+- dig
+- cut, grep
+
+## Scripts
+
+### `http_check.sh`
+
+Realiza una revisión de respuesta HTTP/HTTPS con curl y genera archivos en `out/` para revisión.
+
+### `dns_check.sh`
+
+Verifica registros A/CNAME y escribe salidas en `out/` para revisión.
+
+## Variables de entorno
+
+- `TARGET_URL`: URL objetivo para chequeos HTTP/HTTPS
+
+- `DNS_SERVER`: Servidor DNS para consultas

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -1,0 +1,13 @@
+# Bitácora de sprint 1
+
+## Desarrollo de checkers HTTP/HTTPS y DNS
+
+### Comandos usados
+
+- dig: Permite recopilar información de DNS del dominio pasado como variable de entorno. Se utilizan las banderas `+noall` y `+answer` para obtener solo el resultado de `answer`, que es lo relevante en este proyecto.
+
+- curl: Según su manual, permite comunicarse y enviar o recibir datos de un servidor. En los scripts iniciales permiten recuperar información HTTP/HTTPS de un dominio.
+
+### Motivación
+
+Estos scripts están presentes para un análisis inicial básico de la respuesta del servidor y de su dominio. `http_check.sh` permitirá comparar el resultado entre respuestas HTTP y HTTPS y detectar errores TLS. `dns_check` permite validar nombres y direcciones IP que pueden resultar útiles en el tester para validar endpoints.

--- a/docs/contrato-salidas.md
+++ b/docs/contrato-salidas.md
@@ -1,0 +1,37 @@
+# Contrato de salidas
+
+## Scripts
+
+### `http_check.sh`
+
+#### `http_headers.txt` - `https_headers.txt`
+
+Incluyen las cabeceras de respuesta HTTP/HTTPS a modo de texto plano en varias líneas
+
+#### Validación
+
+Debe empezar con "HTTP/{version} {código de respuesta}"
+
+### `http_trace.txt` - `https_trace.txt`
+
+Traza detallada de la conexión en texto plano.
+
+#### Validación
+
+Debe contener la misma información que las cabeceras en algún punto.
+
+### `dns_a.txt`
+
+Respuesta DNS tipo A en texto plano con una o más líneas que incluyan el dominio, clase, TTL, tipo, IP.
+
+#### Validación
+
+Debe contener al menos una línea con "IN A".
+
+### `dns_cname.txt`
+
+Respuesta DNS tipo CNAME en texto plano con una o más líneas con alias.
+
+#### Validación
+
+Contiene al menos una línea con "IN CNAME".

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+: "${DNS_SERVER:?Define DNS_SERVER}"
+: "${TARGET_URL:?Define TARGET_URL}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$ROOT_DIR/out"
+host="$(echo "$TARGET_URL" | cut -d/ -f3)"
+
+mkdir -p "$OUT_DIR"
+
+dig @"$DNS_SERVER" +noall +answer "$(echo $host | cut -d. -f2-)" A >"$OUT_DIR/dns_a.txt"
+echo "Registro A en out/dns_a.txt"
+dig @"$DNS_SERVER" +noall +answer "$host" CNAME >"$OUT_DIR/dns_cname.txt"
+echo "Registro CNAME en out/dns_cname.txt"

--- a/src/http_check.sh
+++ b/src/http_check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+: "${TARGET_URL:?Define TARGET_URL}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$ROOT_DIR/out"
+proto=$(echo "$TARGET_URL" | cut -d: -f1)
+
+mkdir -p "$OUT_DIR"
+
+curl -sS -D - -o /dev/null "$TARGET_URL" >"$OUT_DIR/${proto}_headers.txt" || true
+echo "Headers escritos en out/"
+curl -v "$TARGET_URL" -o /dev/null >"$OUT_DIR/${proto}_trace.txt" 2>&1 || true
+echo "Traza escrita en out/"


### PR DESCRIPTION
- Implementar scripts http_check.sh y dns_check.sh para revisar respuestas HTTP/HTTPS y DNS de un dominio.
- Variables de entorno requeridas:
  - TARGET_URL: Para revisar la respuesta HTTP/HTTPS del host
  - DNS_SERVER: Para revisar los registros A y CNAME del host
- Salidas en out/:
  - http/https_headers.txt: Incluye cabeceras de respuesta HTTP/HTTPS para comparación de respuestas
  - http/https_trace.txt: Incluye la traza de salida para comparación entre respuestas HTTP/HTTPS
  - dns_a.txt: Repuesta DNS de registro A para analizar su respuesta en el contexto de seguridad TLS
  - dns_cname.txt: Respuesta DNS de registro CNAME para analizar su respuesta en el contexto de seguridad TLS

*Checklist*

- [X] Implementar chequeos HTTP/HTTPS
  - [X] Registrar salidas relevantes
- [X] Implementar chequeos DNS
  - [X] Registrar salidas relevantes