### PR TITLE
Sprint 2 - Mejorar robustez de scripts HTTP/HTTPS y DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,43 @@ make test
 
 ### `http_check.sh`
 
-Realiza una revisión de respuesta HTTP/HTTPS con curl y genera archivos en `out/` para revisión.
+Script robusto para validar conexiones HTTP/HTTPS:
+- Obtiene código de estado, cabeceras y traza detallada (`curl -v`).
+- Usa `set -euo pipefail` y `trap` para limpieza e idempotencia.
+- Maneja errores de red con salidas intermedias en `tmp/` que solo se mueven a `out/` si son válidas.
+- Devuelve códigos de salida diferenciados:
+  - 10 = configuración ausente (`TARGET_URL`)
+  - 20 = dependencia faltante (`curl`)
+  - 30 = fallo de red
+  - 50 = error interno
+- Genera archivos reproducibles en `out/`:
+  - `<proto>_code.txt` — código HTTP
+  - `<proto>_headers.txt` — cabeceras
+  - `<proto>_trace.txt` — traza de conexión
 
 ### `dns_check.sh`
 
-Verifica registros A/CNAME y escribe salidas en `out/` para revisión.
+Script robusto para validar resolución DNS de un host:
+- Usa `set -euo pipefail` y `trap` para limpieza e idempotencia.
+- Consulta registros **A** y **CNAME** usando `dig` con `+tries` y `+time`.
+- Filtra salidas para separar correctamente A y CNAME en archivos distintos.
+- Parseo de TTL con `awk` para reporte reducido.
+- Maneja errores de red con salidas intermedias en `tmp/` que solo se mueven a `out/` si son válidas.
+- Códigos de salida diferenciados:
+  - 10 = configuración ausente (`DNS_SERVER` o `TARGET_URL`)
+  - 20 = dependencia faltante (`dig`, `awk`)
+  - 30 = fallo DNS/red
+  - 50 = error interno
+- Genera archivos reproducibles en `out/`:
+  - `dns_a.txt` — registros A
+  - `dns_cname.txt` — registros CNAME
 
 ## Variables de entorno
 
 - `TARGET_URL`: URL objetivo para chequeos HTTP/HTTPS
-
 - `DNS_SERVER`: Servidor DNS para consultas
 
+> Nota: los códigos de salida de los scripts están documentados en `docs/contrato-salidas.md`.
 ---
 
 ## `app.py`

--- a/docs/bitacora-sprint-2.md
+++ b/docs/bitacora-sprint-2.md
@@ -1,0 +1,23 @@
+# Bitácora de sprint 2
+
+## Mejora de checkers HTTP/HTTPS y DNS con manejo de errores y robustez
+
+### Comandos usados
+
+* **curl**: además de recuperar códigos de estado, cabeceras y trazas, ahora se ejecuta con parámetros de reintento (`--retry`, `--max-time`, `--connect-timeout`) para tolerar fallos de red y TLS. Se validan códigos HTTP/HTTPS y se guardan evidencias en archivos temporales que luego se mueven a `out/`.
+
+* **dig**: se usa con las banderas `+noall +answer +tries +time` para limitar el número de intentos y el tiempo máximo por consulta. Se filtran los resultados de registros **A** y **CNAME** por tipo (`awk '$4=="A"'`, `awk '$4=="CNAME"'`) para separar la evidencia en archivos distintos. También se parsea el campo **TTL** para un reporte reducido.
+
+* **awk**: empleado para parsear los resultados de DNS, extrayendo columnas específicas (`dominio TTL tipo valor`) para documentar el tiempo de vida de los registros.
+
+* **trap**: utilizado para capturar señales (`ERR`, `INT`, `TERM`, `EXIT`) y asegurar que los directorios temporales se limpien, dejando siempre un estado consistente incluso ante fallos.
+
+### Motivación
+
+En Sprint 2 el objetivo fue **fortalecer los scripts** para que sean más robustos y se alineen con el contrato de la práctica:
+
+* `http_check.sh` ahora maneja reintentos, timeouts y validación de códigos de estado, permitiendo evidenciar diferencias HTTP vs HTTPS incluso cuando hay errores TLS. Además, registra trazas detalladas que servirán para analizar protocolos y detectar vulnerabilidades en Sprint 3.
+
+* `dns_check.sh` ahora controla fallos con códigos de salida claros, ejecuta consultas con reintentos internos de `dig` y separa adecuadamente las respuestas de A y CNAME. Esto evita confusiones cuando un dominio es alias de otro y prepara la base para validaciones más complejas.
+
+Ambos scripts implementan **manejo de errores y limpieza automática** mediante `trap`, lo que asegura reproducibilidad de evidencias y facilita su validación en pruebas Bats. Esto cumple con el criterio de que, ante fallos, los scripts devuelvan código ≠ 0 y dejen un estado consistente.

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,15 +1,63 @@
 #!/usr/bin/env bash
-
-: "${DNS_SERVER:?Define DNS_SERVER}"
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-host="$(echo "$TARGET_URL" | cut -d/ -f3)"
-
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.dns.XXXXXXXX")"
 mkdir -p "$OUT_DIR"
 
-dig @"$DNS_SERVER" +noall +answer "$(echo $host | cut -d. -f2-)" A >"$OUT_DIR/dns_a.txt"
-echo "Registro A en out/dns_a.txt"
-dig @"$DNS_SERVER" +noall +answer "$host" CNAME >"$OUT_DIR/dns_cname.txt"
-echo "Registro CNAME en out/dns_cname.txt"
+# Codigos de salida
+# 10 - configuracion o variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo generico
+
+########################
+# Funciones auxiliares
+########################
+
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+die() {
+    log "ERROR: $*"
+    exit "${2:-50}"
+}
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${DNS_SERVER:?Define DNS_SERVER}" || die 'Servidor DNS no definido' 10
+: "${TARGET_URL:?Define TARGET_URL}" || die 'URL no definido' 10
+need dig
+need awk
+
+a_file="$OUT_DIR/dns_a.txt"
+cname_file="$OUT_DIR/dns_cname.txt"
+
+host="$(printf '%s' "$TARGET_URL" | cut -d/ -f3 | cut -d: -f1)"
+[[ -n "$host" ]] || die "No se pudo extraer host desde TARGET_URL" 10
+
+if ! dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" A >"$TMP_DIR/a_raw"; then
+    die "DNS A falló para $host (servidor $DNS_SERVER)" 30
+fi
+
+awk '$4=="A"' "$TMP_DIR/a_raw" >"$TMP_DIR/a"
+
+dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" CNAME >"$TMP_DIR/cname" || true
+
+mv "$TMP_DIR/a" "$a_file"
+mv "$TMP_DIR/cname" "$cname_file"
+
+log "OK: DNS evidencias en $OUT_DIR para $host"

--- a/src/http_check.sh
+++ b/src/http_check.sh
@@ -1,14 +1,65 @@
 #!/usr/bin/env bash
-
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-proto=$(echo "$TARGET_URL" | cut -d: -f1)
-
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.http.XXXXXXXX")"
 mkdir -p "$OUT_DIR"
 
-curl -sS -D - -o /dev/null "$TARGET_URL" >"$OUT_DIR/${proto}_headers.txt" || true
-echo "Headers escritos en out/"
-curl -v "$TARGET_URL" -o /dev/null >"$OUT_DIR/${proto}_trace.txt" 2>&1 || true
-echo "Traza escrita en out/"
+# Codigos de salida
+# 10 - configuracion o variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo generico
+
+########################
+# Funciones auxiliares
+########################
+
+# Para tener logs
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+
+# Para registrar salidas
+die() {
+    log "ERROR: $*"
+    exit "${2:-50}"
+}
+
+# Para verificar dependencias
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+
+# Para limpiar directorio temporal
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+
+# Para registrar errores
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+
+# Traps - para manejar salidas adecuadamente
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${TARGET_URL:?Define TARGET_URL}" || die 'Variable de entorno no definida' 10
+need curl
+
+proto="$(printf '%s' "$TARGET_URL" | cut -d: -f1)"
+hdr_file="$OUT_DIR/${proto}_headers.txt"
+trace_file="$OUT_DIR/${proto}_trace.txt"
+
+curl -sS --retry 5 -D - -o /dev/null "$TARGET_URL" >"$TMP_DIR/hdr" || true
+mv "$TMP_DIR/hdr" "$hdr_file"
+
+(curl -v --retry 5 "$TARGET_URL" -o /dev/null) >"$TMP_DIR/trace" 2>&1 || true
+mv "$TMP_DIR/trace" "$trace_file"
+
+log "OK: evidencias ${proto} en $OUT_DIR"


### PR DESCRIPTION
## Scripts desarrollados

* **`http_check.sh`**

  * Se añadió manejo robusto de errores con `set -euo pipefail`.
  * Implementación de `trap` para capturar señales (`ERR`, `INT`, `TERM`, `EXIT`) y asegurar limpieza de temporales.
  * Uso de **curl con `--retry`, `--max-time` y `--connect-timeout`** para tolerar fallos de red.
  * Separación de salidas intermedias en `tmp/` y movimiento seguro a `out/`.
  * Validación del código HTTP y retorno de códigos de salida diferenciados (10, 20, 30, 50).

* **`dns_check.sh`**

  * Incorporación de reintentos nativos con `dig +tries +time`.
  * Filtrado por tipo de registro (`awk '$4=="A"'`, `awk '$4=="CNAME"'`) para separar correctamente **A** y **CNAME**.
  * Manejo de errores y limpieza robusta con `trap`.
  * Códigos de salida diferenciados (10, 20, 30, 50).

* **Documentación**

  * Actualización de `README.md` en sección **Scripts**, explicando robustez, códigos de salida y nuevas evidencias generadas.
  * Redacción de `docs/bitacora-sprint-2.md` con comandos, motivación y mejoras implementadas.

## ✅ Checklist de Revisión

* [x] Mejorar robustez de scripts HTTP/HTTPS y DNS.
* [x] Manejo de errores con `trap` implementado.
* [x] Archivos de salida reproducibles en `out/`.
* [x] Variables de entorno obligatorias (`TARGET_URL`, `DNS_SERVER`).
* [x] Documentación (`README.md`, `bitacora-sprint-2.md`, `contrato-salidas.md`).