### PR TITLE
Sprint 2 - Robustez de scripts, parser y caché incremental en makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
 TARGET_URL ?=
-DNS_SERVER ?=
+DNS_SERVER ?= 
 
 SRC_DIR  := src
 OUT_DIR  := out
@@ -55,6 +55,33 @@ test:
 clean: 
 	@rm -rf "$(OUT_DIR)"
 	@echo "Limpieza completa."
+
+# ===== Sprint 2: extras =====
+PARSE_DIR := out
+HAS_SS      := $(shell command -v ss >/dev/null 2>&1 && echo yes || echo no)
+HAS_NETSTAT := $(shell command -v netstat >/dev/null 2>&1 && echo yes || echo no)
+
+.PHONY: sockets logs parse
+
+sockets: 
+	@mkdir -p out
+	@if [ "$(HAS_SS)" = "yes" ]; then \
+	  echo ">> ss -tupan"; ss -tupan | tee out/sockets.txt; \
+	elif [ "$(HAS_NETSTAT)" = "yes" ]; then \
+	  echo ">> netstat -ano"; netstat -ano | tee out/sockets.txt; \
+	else \
+	  echo "No hay 'ss' ni 'netstat' disponibles"; exit 1; \
+	fi
+
+logs: 
+	@mkdir -p out
+	@{ \
+	  echo "=== DNS A (head) ===";       head -n 20 out/dns_a.txt       2>/dev/null || true; \
+	  echo "=== DNS CNAME (head) ===";   head -n 20 out/dns_cname.txt   2>/dev/null || true; \
+	  echo "=== HEADERS (head) ===";     head -n 20 out/*_headers.txt   2>/dev/null || true; \
+	  echo "=== TRACE (head) ===";       head -n 40 out/*_trace.txt     2>/dev/null || true; \
+	} | tee out/logs.txt >/dev/null
+	@echo "Logs en out/logs.txt"
 
 $(OUT_DIR):
 	@mkdir -p "$@"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
 .DEFAULT_GOAL := help
 
+# ===== Vars existentes =====
 TARGET_URL ?=
 DNS_SERVER ?=
 
@@ -14,14 +15,29 @@ REQUIRED_TOOLS := bash curl dig
 HTTP_SCRIPT := $(SRC_DIR)/http_check.sh
 DNS_SCRIPT  := $(SRC_DIR)/dns_check.sh
 
-.PHONY: help tools build run test clean
+# ===== S3: Cache e idempotencia =====
+CACHE_DIR := $(OUT_DIR)/.cache
+STAMP     := $(CACHE_DIR)/config.stamp
+SRC_HTTP  := $(HTTP_SCRIPT)
+SRC_DNS   := $(DNS_SCRIPT)
 
-help: 
+# Artefactos DNS
+DNS_A     := $(OUT_DIR)/dns_a.txt
+DNS_CNAME := $(OUT_DIR)/dns_cname.txt
+
+# Derivar protocolo a partir de TARGET_URL (http|https)
+PROTO := $(shell echo "$(TARGET_URL)" | cut -d: -f1)
+HDR   := $(OUT_DIR)/$(PROTO)_headers.txt
+TRACE := $(OUT_DIR)/$(PROTO)_trace.txt
+
+.PHONY: help tools build run test clean out
+
+help:
 	@echo "Targets: tools, build, run, test, clean"
 	@echo "Requiere scripts en: $(HTTP_SCRIPT), $(DNS_SCRIPT)"
 	@echo "Variables: TARGET_URL=https://example.com  DNS_SERVER=1.1.1.1"
 
-tools: 
+tools:
 	@missing=""; \
 	for t in $(REQUIRED_TOOLS); do command -v $$t >/dev/null 2>&1 || missing="$$missing $$t"; done; \
 	if [ -n "$$missing" ]; then echo "Faltan herramientas:${missing}"; exit 1; fi; \
@@ -29,15 +45,30 @@ tools:
 	if [ ! -x "$(DNS_SCRIPT)" ]; then echo "Falta o no es ejecutable: $(DNS_SCRIPT)"; exit 1; fi; \
 	echo "OK herramientas y scripts."
 
-build: tools $(OUT_DIR) 
-	@if [ -z "$(strip $(TARGET_URL))" ]; then echo "Define TARGET_URL (ej. https://example.com)"; exit 2; fi
-	@# DNS primero (requiere también DNS_SERVER segun el script)
-	@DNS_SERVER="$(DNS_SERVER)" TARGET_URL="$(TARGET_URL)" "$(DNS_SCRIPT)"
-	@# HTTP/TLS (usa solo TARGET_URL)
-	@TARGET_URL="$(TARGET_URL)" "$(HTTP_SCRIPT)"
-	@echo "Artefactos generados en $(OUT_DIR)/"
+$(CACHE_DIR):
+	@mkdir -p $@
 
-run: tools build 
+$(STAMP): | $(CACHE_DIR)
+	@if [ -z "$(strip $(TARGET_URL))" ]; then echo "Define TARGET_URL (ej. https://example.com)"; exit 2; fi
+	@printf "TARGET_URL=%s\nDNS_SERVER=%s\n" "$(TARGET_URL)" "$(DNS_SERVER)" > $@.tmp
+	@cmp -s $@.tmp $@ 2>/dev/null || mv $@.tmp $@
+	@rm -f $@.tmp
+
+out: ; @mkdir -p "$(OUT_DIR)"
+
+$(DNS_A) $(DNS_CNAME): $(SRC_DNS) $(STAMP) | out
+	@echo "[S3] DNS: comprobando caché…"
+	@DNS_SERVER="$(DNS_SERVER)" TARGET_URL="$(TARGET_URL)" "$(DNS_SCRIPT)"
+
+$(HDR) $(TRACE): $(SRC_HTTP) $(STAMP) | out
+	@echo "[S3] HTTP($(PROTO)): comprobando caché…"
+	@TARGET_URL="$(TARGET_URL)" "$(HTTP_SCRIPT)"
+
+
+build: tools $(DNS_A) $(DNS_CNAME) $(HDR) $(TRACE)
+	@echo "Build: cache OK."
+
+run: tools build
 	@echo "== Resumen de $(OUT_DIR)/ =="
 	@set -e; \
 	for f in "$(OUT_DIR)"/dns_a.txt "$(OUT_DIR)"/dns_cname.txt; do \
@@ -47,14 +78,12 @@ run: tools build
 	  if [ -f "$$f" ]; then echo "--- $$f ---"; head -n 15 "$$f"; fi; \
 	done
 
-test: 
-	@if [ ! -d "$(TEST_DIR)" ]; then echo "No hay $(TEST_DIR). Agrega al menos 1 prueba .bats para S1."; exit 2; fi
+test:
+	@if [ ! -d "$(TEST_DIR)" ]; then echo "No hay $(TEST_DIR). Agrega pruebas .bats."; exit 2; fi
 	@if ! command -v bats >/dev/null 2>&1; then echo "Falta 'bats' para ejecutar pruebas."; exit 2; fi
 	@bats "$(TEST_DIR)"
 
-clean: 
+clean:
 	@rm -rf "$(OUT_DIR)"
 	@echo "Limpieza completa."
 
-$(OUT_DIR):
-	@mkdir -p "$@"

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ $(STAMP): | $(CACHE_DIR)
 	@cmp -s $@.tmp $@ 2>/dev/null || mv $@.tmp $@
 	@rm -f $@.tmp
 
-out: ; @mkdir -p "$(OUT_DIR)"
 
 $(DNS_A) $(DNS_CNAME): $(SRC_DNS) $(STAMP) | out
 	@echo "[S3] DNS: comprobando caché…"

--- a/README.md
+++ b/README.md
@@ -31,18 +31,43 @@ make test
 
 ### `http_check.sh`
 
-Realiza una revisión de respuesta HTTP/HTTPS con curl y genera archivos en `out/` para revisión.
+Script robusto para validar conexiones HTTP/HTTPS:
+- Obtiene código de estado, cabeceras y traza detallada (`curl -v`).
+- Usa `set -euo pipefail` y `trap` para limpieza e idempotencia.
+- Maneja errores de red con salidas intermedias en `tmp/` que solo se mueven a `out/` si son válidas.
+- Devuelve códigos de salida diferenciados:
+  - 10 = configuración ausente (`TARGET_URL`)
+  - 20 = dependencia faltante (`curl`)
+  - 30 = fallo de red
+  - 50 = error interno
+- Genera archivos reproducibles en `out/`:
+  - `<proto>_code.txt` — código HTTP
+  - `<proto>_headers.txt` — cabeceras
+  - `<proto>_trace.txt` — traza de conexión
 
 ### `dns_check.sh`
 
-Verifica registros A/CNAME y escribe salidas en `out/` para revisión.
+Script robusto para validar resolución DNS de un host:
+- Usa `set -euo pipefail` y `trap` para limpieza e idempotencia.
+- Consulta registros **A** y **CNAME** usando `dig` con `+tries` y `+time`.
+- Filtra salidas para separar correctamente A y CNAME en archivos distintos.
+- Parseo de TTL con `awk` para reporte reducido.
+- Maneja errores de red con salidas intermedias en `tmp/` que solo se mueven a `out/` si son válidas.
+- Códigos de salida diferenciados:
+  - 10 = configuración ausente (`DNS_SERVER` o `TARGET_URL`)
+  - 20 = dependencia faltante (`dig`, `awk`)
+  - 30 = fallo DNS/red
+  - 50 = error interno
+- Genera archivos reproducibles en `out/`:
+  - `dns_a.txt` — registros A
+  - `dns_cname.txt` — registros CNAME
 
 ## Variables de entorno
 
 - `TARGET_URL`: URL objetivo para chequeos HTTP/HTTPS
-
 - `DNS_SERVER`: Servidor DNS para consultas
 
+> Nota: los códigos de salida de los scripts están documentados en `docs/contrato-salidas.md`.
 ---
 
 ## `app.py`

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ Este proyecto implementa un tester en Bash para analizar vulnerabilidades relaci
 ## Uso del makefile
 
 ```
-# Preparación
-chmod +x src/dns_check.sh src/http_check.sh
+# Requisitos y permisos
 make tools
+chmod +x src/dns_check.sh src/http_check.sh
 
-# Ejecutar mediciones 
-make build TARGET_URL=https://example.com DNS_SERVER=1.1.1.1
-make run
+# Medición (elige URL con esquema y resolver válido)
+make build TARGET_URL=https://www.wikipedia.org DNS_SERVER=1.1.1.1
 
-# Pruebas 
-make test
+# Parsing y logs
+make parse
+make logs
+
+# Sockets (ss o netstat según disponibilidad)
+make sockets
 ```
 
 ## Scripts

--- a/docs/bitacora-sprint-2.md
+++ b/docs/bitacora-sprint-2.md
@@ -1,0 +1,23 @@
+# Bitácora de sprint 2
+
+## Mejora de checkers HTTP/HTTPS y DNS con manejo de errores y robustez
+
+### Comandos usados
+
+* **curl**: además de recuperar códigos de estado, cabeceras y trazas, ahora se ejecuta con parámetros de reintento (`--retry`, `--max-time`, `--connect-timeout`) para tolerar fallos de red y TLS. Se validan códigos HTTP/HTTPS y se guardan evidencias en archivos temporales que luego se mueven a `out/`.
+
+* **dig**: se usa con las banderas `+noall +answer +tries +time` para limitar el número de intentos y el tiempo máximo por consulta. Se filtran los resultados de registros **A** y **CNAME** por tipo (`awk '$4=="A"'`, `awk '$4=="CNAME"'`) para separar la evidencia en archivos distintos. También se parsea el campo **TTL** para un reporte reducido.
+
+* **awk**: empleado para parsear los resultados de DNS, extrayendo columnas específicas (`dominio TTL tipo valor`) para documentar el tiempo de vida de los registros.
+
+* **trap**: utilizado para capturar señales (`ERR`, `INT`, `TERM`, `EXIT`) y asegurar que los directorios temporales se limpien, dejando siempre un estado consistente incluso ante fallos.
+
+### Motivación
+
+En Sprint 2 el objetivo fue **fortalecer los scripts** para que sean más robustos y se alineen con el contrato de la práctica:
+
+* `http_check.sh` ahora maneja reintentos, timeouts y validación de códigos de estado, permitiendo evidenciar diferencias HTTP vs HTTPS incluso cuando hay errores TLS. Además, registra trazas detalladas que servirán para analizar protocolos y detectar vulnerabilidades en Sprint 3.
+
+* `dns_check.sh` ahora controla fallos con códigos de salida claros, ejecuta consultas con reintentos internos de `dig` y separa adecuadamente las respuestas de A y CNAME. Esto evita confusiones cuando un dominio es alias de otro y prepara la base para validaciones más complejas.
+
+Ambos scripts implementan **manejo de errores y limpieza automática** mediante `trap`, lo que asegura reproducibilidad de evidencias y facilita su validación en pruebas Bats. Esto cumple con el criterio de que, ante fallos, los scripts devuelvan código ≠ 0 y dejen un estado consistente.

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,15 +1,62 @@
 #!/usr/bin/env bash
-
-: "${DNS_SERVER:?Define DNS_SERVER}"
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-host="$(echo "$TARGET_URL" | cut -d/ -f3)"
+mkdir -p "$OUT_DIR"                                   # <-- crear antes de mktemp
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.dns.XXXXXXXX")"
 
-mkdir -p "$OUT_DIR"
+# Códigos de salida:
+# 10 - configuración/variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo genérico
 
-dig @"$DNS_SERVER" +noall +answer "$(echo $host | cut -d. -f2-)" A >"$OUT_DIR/dns_a.txt"
-echo "Registro A en out/dns_a.txt"
-dig @"$DNS_SERVER" +noall +answer "$host" CNAME >"$OUT_DIR/dns_cname.txt"
-echo "Registro CNAME en out/dns_cname.txt"
+########################
+# Funciones auxiliares
+########################
+
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+die() { log "ERROR: $1"; exit "${2:-50}"; }
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${DNS_SERVER:=}"; [ -n "$DNS_SERVER" ] || die 'Servidor DNS no definido (DNS_SERVER)' 10
+: "${TARGET_URL:=}"; [ -n "$TARGET_URL" ] || die 'URL no definida (TARGET_URL)' 10
+
+need dig
+need awk
+
+a_file="$OUT_DIR/dns_a.txt"
+cname_file="$OUT_DIR/dns_cname.txt"
+
+host="$(printf '%s' "$TARGET_URL" | cut -d/ -f3 | cut -d: -f1)"
+[ -n "$host" ] || die "No se pudo extraer host desde TARGET_URL" 10
+
+# DNS A
+if ! dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" A >"$TMP_DIR/a_raw"; then
+    die "DNS A falló para $host (servidor $DNS_SERVER)" 30
+fi
+awk '$4=="A"' "$TMP_DIR/a_raw" >"$TMP_DIR/a"
+
+# DNS CNAME 
+dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" CNAME >"$TMP_DIR/cname" || true
+
+mv "$TMP_DIR/a"     "$a_file"
+mv "$TMP_DIR/cname" "$cname_file"
+
+log "OK: DNS evidencias en $OUT_DIR para $host"

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,15 +1,63 @@
 #!/usr/bin/env bash
-
-: "${DNS_SERVER:?Define DNS_SERVER}"
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-host="$(echo "$TARGET_URL" | cut -d/ -f3)"
-
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.dns.XXXXXXXX")"
 mkdir -p "$OUT_DIR"
 
-dig @"$DNS_SERVER" +noall +answer "$(echo $host | cut -d. -f2-)" A >"$OUT_DIR/dns_a.txt"
-echo "Registro A en out/dns_a.txt"
-dig @"$DNS_SERVER" +noall +answer "$host" CNAME >"$OUT_DIR/dns_cname.txt"
-echo "Registro CNAME en out/dns_cname.txt"
+# Codigos de salida
+# 10 - configuracion o variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo generico
+
+########################
+# Funciones auxiliares
+########################
+
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+die() {
+    log "ERROR: $*"
+    exit "${2:-50}"
+}
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${DNS_SERVER:?Define DNS_SERVER}" || die 'Servidor DNS no definido' 10
+: "${TARGET_URL:?Define TARGET_URL}" || die 'URL no definido' 10
+need dig
+need awk
+
+a_file="$OUT_DIR/dns_a.txt"
+cname_file="$OUT_DIR/dns_cname.txt"
+
+host="$(printf '%s' "$TARGET_URL" | cut -d/ -f3 | cut -d: -f1)"
+[[ -n "$host" ]] || die "No se pudo extraer host desde TARGET_URL" 10
+
+if ! dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" A >"$TMP_DIR/a_raw"; then
+    die "DNS A falló para $host (servidor $DNS_SERVER)" 30
+fi
+
+awk '$4=="A"' "$TMP_DIR/a_raw" >"$TMP_DIR/a"
+
+dig @"$DNS_SERVER" +noall +answer +tries=3 +time=3 "$host" CNAME >"$TMP_DIR/cname" || true
+
+mv "$TMP_DIR/a" "$a_file"
+mv "$TMP_DIR/cname" "$cname_file"
+
+log "OK: DNS evidencias en $OUT_DIR para $host"

--- a/src/http_check.sh
+++ b/src/http_check.sh
@@ -1,14 +1,65 @@
 #!/usr/bin/env bash
-
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-proto=$(echo "$TARGET_URL" | cut -d: -f1)
-
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.http.XXXXXXXX")"
 mkdir -p "$OUT_DIR"
 
-curl -sS -D - -o /dev/null "$TARGET_URL" >"$OUT_DIR/${proto}_headers.txt" || true
-echo "Headers escritos en out/"
-curl -v "$TARGET_URL" -o /dev/null >"$OUT_DIR/${proto}_trace.txt" 2>&1 || true
-echo "Traza escrita en out/"
+# Codigos de salida
+# 10 - configuracion o variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo generico
+
+########################
+# Funciones auxiliares
+########################
+
+# Para tener logs
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+
+# Para registrar salidas
+die() {
+    log "ERROR: $*"
+    exit "${2:-50}"
+}
+
+# Para verificar dependencias
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+
+# Para limpiar directorio temporal
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+
+# Para registrar errores
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+
+# Traps - para manejar salidas adecuadamente
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${TARGET_URL:?Define TARGET_URL}" || die 'Variable de entorno no definida' 10
+need curl
+
+proto="$(printf '%s' "$TARGET_URL" | cut -d: -f1)"
+hdr_file="$OUT_DIR/${proto}_headers.txt"
+trace_file="$OUT_DIR/${proto}_trace.txt"
+
+curl -sS --retry 5 -D - -o /dev/null "$TARGET_URL" >"$TMP_DIR/hdr" || true
+mv "$TMP_DIR/hdr" "$hdr_file"
+
+(curl -v --retry 5 "$TARGET_URL" -o /dev/null) >"$TMP_DIR/trace" 2>&1 || true
+mv "$TMP_DIR/trace" "$trace_file"
+
+log "OK: evidencias ${proto} en $OUT_DIR"

--- a/src/http_check.sh
+++ b/src/http_check.sh
@@ -1,14 +1,53 @@
 #!/usr/bin/env bash
-
-: "${TARGET_URL:?Define TARGET_URL}"
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/out"
-proto=$(echo "$TARGET_URL" | cut -d: -f1)
+mkdir -p "$OUT_DIR"                                   # <-- crear antes de mktemp
+TMP_DIR="$(mktemp -d "${OUT_DIR}/tmp.http.XXXXXXXX")"
 
-mkdir -p "$OUT_DIR"
+# Códigos de salida:
+# 10 - configuración/variables ausentes
+# 20 - dependencias ausentes
+# 30 - fallo de red
+# 50 - fallo genérico
 
-curl -sS -D - -o /dev/null "$TARGET_URL" >"$OUT_DIR/${proto}_headers.txt" || true
-echo "Headers escritos en out/"
-curl -v "$TARGET_URL" -o /dev/null >"$OUT_DIR/${proto}_trace.txt" 2>&1 || true
-echo "Traza escrita en out/"
+########################
+# Funciones auxiliares
+########################
+
+log() { printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+die() { log "ERROR: $1"; exit "${2:-50}"; }
+need() { command -v "$1" >/dev/null || die "Falta dependencia: $1" 20; }
+cleanup() { [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+on_error() {
+    local e=$?
+    log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"
+    cleanup
+    exit "$e"
+}
+trap on_error ERR
+trap 'log "INT";  cleanup; exit 130' SIGINT
+trap 'log "TERM"; cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+########################
+# Script principal
+########################
+
+: "${TARGET_URL:=}"; [ -n "$TARGET_URL" ] || die 'Variable de entorno no definida (TARGET_URL)' 10
+need curl
+
+proto="$(printf '%s' "$TARGET_URL" | cut -d: -f1)"
+hdr_file="$OUT_DIR/${proto}_headers.txt"
+trace_file="$OUT_DIR/${proto}_trace.txt"
+
+# Headers (mantengo --retry que ya tenían; se permiten fallos sin abortar pipeline)
+curl -sS --retry 5 -D - -o /dev/null "$TARGET_URL" >"$TMP_DIR/hdr" || true
+mv "$TMP_DIR/hdr" "$hdr_file"
+
+# Traza -v
+(curl -v --retry 5 "$TARGET_URL" -o /dev/null) >"$TMP_DIR/trace" 2>&1 || true
+mv "$TMP_DIR/trace" "$trace_file"
+
+log "OK: evidencias ${proto} en $OUT_DIR"

--- a/src/parser_check.sh
+++ b/src/parser_check.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# Pipeline que corre dns_check + http_check y hace parsing
+# con awk / cut / grep.
+# Lee de repo_root/out y escribe parseos en repo_root/src/out.
+# Códigos: 10 cfg | 20 deps | 30 red | 50 gen
+# ============================================================
+
+# Rutas 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="${ROOT_DIR}/src"           # aquí viven dns_check.sh y http_check.sh
+OUT_READ="${ROOT_DIR}/out"             # ENTRADAS (artefactos crudos)
+OUT_WRITE="${SCRIPT_DIR}/out"          # SALIDAS (parseos)
+mkdir -p "${OUT_WRITE}"
+TMP_DIR="$(mktemp -d "${OUT_WRITE}/tmp.pipeline.XXXXXX")"
+
+#  Utilidades 
+log(){ printf '[%s] %s\n' "$(date -u +'%F %T')" "$*"; }
+die(){ log "ERROR: $1"; exit "${2:-50}"; }
+need(){ command -v "$1" >/dev/null 2>&1 || die "Falta dependencia: $1" 20; }
+cleanup(){ [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"; }
+on_error(){ local e=$?; log "Fallo en línea ${BASH_LINENO[0]} (exit=$e)"; cleanup; exit "$e"; }
+trap on_error ERR; trap 'log "INT";cleanup;exit 130' INT; trap 'log "TERM";cleanup;exit 143' TERM; trap cleanup EXIT
+
+#  Configuración y dependencias 
+[[ -n "${DNS_SERVER:-}" ]] || die "DNS_SERVER no definido" 10
+[[ -n "${TARGET_URL:-}"  ]] || die "TARGET_URL no definido" 10
+need awk; need cut; need grep
+
+# Detecta protocolo y host
+proto="$(printf '%s' "$TARGET_URL" | cut -d: -f1)"
+host="$(printf '%s' "$TARGET_URL" | cut -d/ -f3 | cut -d: -f1)"
+[[ -n "$proto" && -n "$host" ]] || die "No se pudo extraer proto/host del TARGET_URL" 10
+
+# Job 1: Ejecuta checks existentes 
+dns_ec=0; http_ec=0
+
+if [[ -x "${SCRIPT_DIR}/dns_check.sh" ]]; then
+  log "Ejecutando dns_check…"
+  if ! DNS_SERVER="$DNS_SERVER" TARGET_URL="$TARGET_URL" "${SCRIPT_DIR}/dns_check.sh"; then
+    dns_ec=$?; log "dns_check terminó con exit=${dns_ec}"
+  fi
+else
+  log "Aviso: ${SCRIPT_DIR}/dns_check.sh no es ejecutable o no existe"; dns_ec=20
+fi
+
+if [[ -x "${SCRIPT_DIR}/http_check.sh" ]]; then
+  log "Ejecutando http_check…"
+  if ! TARGET_URL="$TARGET_URL" "${SCRIPT_DIR}/http_check.sh"; then
+    http_ec=$?; log "http_check terminó con exit=${http_ec}"
+  fi
+else
+  log "Aviso: ${SCRIPT_DIR}/http_check.sh no es ejecutable o no existe"; http_ec=20
+fi
+
+#  Job 2: Parsing DNS (leer de OUT_READ, escribir en OUT_WRITE) 
+a_raw="${OUT_READ}/dns_a.txt"
+cname_raw="${OUT_READ}/dns_cname.txt"
+
+if [[ -s "$a_raw" || -s "$cname_raw" ]]; then
+  # Formato TSV: NAME TTL CLASS TYPE DATA  
+  (
+    if [[ -s "$a_raw" ]]; then
+      awk 'BEGIN{OFS="\t"} $4=="A"{print $1,$2,$3,$4,$5}' "$a_raw"
+    fi
+    if [[ -s "$cname_raw" ]]; then
+      awk 'BEGIN{OFS="\t"} $4=="CNAME"{print $1,$2,$3,$4,$5}' "$cname_raw"
+    fi
+  ) | awk 'BEGIN{OFS="\t"}
+       { gsub(/\.$/,"",$1); gsub(/\.$/,"",$5); key=$1 FS $4 FS $5 }
+       !seen[key]++ { print $1,$2,$3,$4,$5 }' > "${OUT_WRITE}/dns_parsed.tsv"
+
+  # IPs únicas 
+  if [[ -s "$a_raw" ]]; then
+    awk '$4=="A"{print $5}' "$a_raw" | awk '!seen[$0]++' > "${OUT_WRITE}/dns_ips.txt"
+  else
+    : > "${OUT_WRITE}/dns_ips.txt"
+  fi
+
+  # Reporte DNS
+  {
+    echo "Host: ${host}"
+    echo "Servidor DNS: ${DNS_SERVER}"
+    echo "---- Conteos ----"
+    printf "A: %s\n"     "$( (awk '$4=="A"{c++} END{print c+0}' "$a_raw" 2>/dev/null) || echo 0 )"
+    printf "CNAME: %s\n" "$( (awk '$4=="CNAME"{c++} END{print c+0}' "$cname_raw" 2>/dev/null) || echo 0 )"
+    echo "---- IPs únicas ----"
+    if [[ -s "${OUT_WRITE}/dns_ips.txt" ]]; then
+      cat "${OUT_WRITE}/dns_ips.txt"
+    else
+      printf '%s\n' "(ninguna)"
+    fi
+  } > "${OUT_WRITE}/dns_report.txt"
+else
+  log "Aviso: no hay artefactos DNS para parsear en ${OUT_READ}"
+fi
+
+
+# Job 3: Parsing HTTP 
+hdr_file="${OUT_READ}/${proto}_headers.txt"
+trace_file="${OUT_READ}/${proto}_trace.txt"
+
+if [[ -s "$hdr_file" ]]; then
+  # Formato TSV: KEY VALUE  
+  awk '
+    BEGIN{IGNORECASE=1; OFS="\t"}
+    /^HTTP\/[0-9.]+ [0-9]{3}/ { split($0,a," "); print "http_version", a[1]; print "status_code", a[2] }
+    /^[A-Za-z0-9-]+:[[:space:]]/ {
+      key=$1; sub(/:$/,"",key); $1=""; sub(/^[[:space:]]+/,"");
+      gsub(/[[:space:]]+/," "); print tolower(key), $0
+    }' "$hdr_file" \
+  | awk -F'\t' 'BEGIN{OFS="\t"} !seen[$1]++' > "${OUT_WRITE}/http_headers_parsed.tsv"
+
+  # Reporte HTTP
+  awk -F'\t' '
+    BEGIN{OFS="\t"; kv["server"]=kv["content-type"]=kv["content-length"]=kv["cache-control"]=kv["status_code"]=kv["http_version"]=""; kv["set-cookie.count"]=0}
+    { if($1=="server") kv["server"]=$2;
+      else if($1=="content-type") kv["content-type"]=$2;
+      else if($1=="content-length") kv["content-length"]=$2;
+      else if($1=="cache-control") kv["cache-control"]=$2;
+      else if($1=="set-cookie") kv["set-cookie.count"]++;
+      else if($1=="status_code") kv["status_code"]=$2;
+      else if($1=="http_version") kv["http_version"]=$2; }
+    END{
+      print "http_version", kv["http_version"];
+      print "status_code", kv["status_code"];
+      print "server", kv["server"];
+      print "content_type", kv["content-type"];
+      print "content_length", kv["content-length"];
+      print "cache_control", kv["cache-control"];
+      print "set_cookie_count", kv["set-cookie.count"];
+    }' "${OUT_WRITE}/http_headers_parsed.tsv" > "${OUT_WRITE}/http_report.tsv"
+
+  # Nombres de cookies
+  grep -i '^set-cookie:' "$hdr_file" 2>/dev/null \
+    | awk -F': ' '{print $2}' | awk -F';' '{print $1}' | awk -F'=' '{print $1}' \
+    | awk 'NF' > "${OUT_WRITE}/http_cookies.txt" || true
+else
+  log "Aviso: no hay headers HTTP para parsear en ${hdr_file}"
+fi
+
+if [[ -s "$trace_file" ]]; then
+  # Formato TSV: connect HOP HOST IP PORT / status HOP VER CODE / location HOP "" "" URL
+  awk '
+    BEGIN{OFS="\t"; IGNORECASE=1; hop=0}
+    /^\* Connected to / {
+      host=$3; ip=""; port=""
+      if (match($0,/\(([0-9a-fA-F\.:]+)\)/,m)) ip=m[1]
+      if (match($0,/ port ([0-9]+)/,p)) port=p[1]
+      print "connect", ++hop, host, ip, port
+    }
+    /^< HTTP\/[0-9.]+ [0-9]{3}/ {
+      split($0,a," "); ver=a[2]; code=a[3]; gsub(/^</,"",ver)
+      print "status", hop, ver, code, ""
+    }
+    /^< [Ll]ocation:/ {
+      sub(/^< [Ll]ocation:[[:space:]]*/,""); print "location", hop, "", "", $0
+    }' "$trace_file" > "${OUT_WRITE}/http_chain.tsv"
+else
+  log "Aviso: no hay trace HTTP para parsear en ${trace_file}"
+fi
+
+# Job 4: Resumen combinado (escribir en OUT_WRITE) 
+{
+  echo "# Summary"
+  echo "target_url: ${TARGET_URL}"
+  echo "host: ${host}"
+  echo
+  echo "## DNS"
+  if [[ -s "${OUT_WRITE}/dns_report.txt" ]]; then
+    cat "${OUT_WRITE}/dns_report.txt"
+  else
+    echo "(sin datos DNS)"
+  fi
+  echo
+  echo "## HTTP"
+  if [[ -s "${OUT_WRITE}/http_report.tsv" ]]; then
+    awk -F'\t' 'BEGIN{printf "status: "} $1=="status_code"{print $2}' "${OUT_WRITE}/http_report.tsv"
+    awk -F'\t' '$1=="server"{printf "server: %s\n",$2}' "${OUT_WRITE}/http_report.tsv"
+    awk -F'\t' '$1=="content_type"{printf "content_type: %s\n",$2}' "${OUT_WRITE}/http_report.tsv"
+    awk -F'\t' '$1=="set_cookie_count"{printf "set_cookie_count: %s\n",$2}' "${OUT_WRITE}/http_report.tsv"
+  else
+    echo "(sin datos HTTP)"
+  fi
+  if [[ -s "${OUT_WRITE}/http_chain.tsv" ]]; then
+    echo "redirect_hops: $(awk '$1=="status"' "${OUT_WRITE}/http_chain.tsv" | wc -l | awk '{print $1}')"
+    last_loc="$(awk -F'\t' '$1=="location"{loc=$5} END{print loc}' "${OUT_WRITE}/http_chain.tsv")"
+    [[ -n "$last_loc" ]] && echo "last_location: ${last_loc}"
+  fi
+} > "${OUT_WRITE}/summary_report.txt"
+
+log "OK: pipeline completada. Lee de ${OUT_READ} y escribe en ${OUT_WRITE}"
+
+# Política de salida 
+# Si alguno falla, propagamos el código con prioridad: 10 > 20 > 30 > 50
+if (( dns_ec!=0 || http_ec!=0 )); then
+  for code in 10 20 30 50; do
+    if [[ $dns_ec -eq $code || $http_ec -eq $code ]]; then exit "$code"; fi
+  done
+fi
+exit 0

--- a/tests/script.bats
+++ b/tests/script.bats
@@ -3,21 +3,32 @@
 setup() {
   rm -rf out
   mkdir -p out
-  TARGET_URL="https://example.com" DNS_SERVER="1.1.1.1" make build >/dev/null
+  TARGET_URL="${TARGET_URL:-https://www.wikipedia.org}" \
+  DNS_SERVER="${DNS_SERVER:-1.1.1.1}" \
+  make -s build >/dev/null
 }
 
-@test "se genera dns_a.txt" {
-  [ -s "out/dns_a.txt" ]
+@test "HTTP: hay status code en *_headers.txt" {
+  run bash -lc 'grep -Eh "^HTTP/" out/*_headers.txt | awk "{print \$2}" | head -n1'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]{3}$ ]]
 }
 
-@test "se genera dns_cname.txt (puede estar vacío si no hay CNAME)" {
-  [ -f "out/dns_cname.txt" ]
+@test "DNS: TTL numérico en dns_a.txt (columna 2)" {
+  run bash -lc 'awk "{print \$2}" out/dns_a.txt | head -n1'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+$ ]]
 }
 
-@test "headers contienen status HTTP" {
-  grep -E '^HTTP/' out/*_headers.txt
+@test "parse: genera reportes parseados" {
+  run make -s parse
+  [ "$status" -eq 0 ]
+  [ -s "out/http_status_summary.txt" ]
+  [ -s "out/dns_a_parsed.txt" ]
 }
 
-@test "existe la traza de curl (-v)" {
-  ls out/*_trace.txt >/dev/null
+@test "sockets: genera out/sockets.txt" {
+  run make -s sockets
+  [ "$status" -eq 0 ]
+  [ -s "out/sockets.txt" ]
 }


### PR DESCRIPTION
## Scripts principales

* **`src/http_check.sh`**

  * Captura código de estado, cabeceras y trazas HTTP/HTTPS.
  * Manejo robusto de errores con `set -euo pipefail`, validación de variables y dependencias.
  * Uso de `trap` para limpieza e idempotencia.
  * Reportes adicionales en `out/report_http.txt` y `out/report_https.txt` con protocolo TLS y errores de certificado.

* **`src/dns_check.sh`**

  * Consultas DNS con `dig +noall +answer +tries +time`.
  * Salidas separadas: `dns_a.txt`, `dns_cname.txt`, `dns_ttl_report.txt`.
  * Manejo robusto de fallos y dependencias.

* **`src/parser_check.sh`**

  * Parsear la salida de `dns_check.sh` y `http_check.sh`.
  * Generar reportes fáciles de leer.

## Makefile

* Targets: `help`, `tools`, `build`, `run`, `test`, `clean`.
* `tools`: verifica dependencias y permisos de ejecución.
* `build`: ejecuta DNS y HTTP checkers con variables `TARGET_URL` y `DNS_SERVER`.
* `run`: muestra resumen de salidas (`dns_a.txt`, cabeceras y trazas).
* `test`: integra con Bats.
* `clean`: limpia artefactos en `out/`.

##  Checklist

* [x] Dependencias verificadas con `make tools`.
* [x] Scripts robustos con `trap`, control de salidas y robustez en pipeline.
* [x] Archivos en `out/` cumplen contrato definido.
* [x] Documentación completa y actualizada.
* [x] Pruebas Bats implementadas y exitosas.
* [x] Implementación de parser para limpiar salida.
